### PR TITLE
Fix: Simplify get_env parameters and fix related bugs

### DIFF
--- a/utu/config/agent_config.py
+++ b/utu/config/agent_config.py
@@ -80,6 +80,6 @@ class AgentConfig(ConfigBaseModel):
 
     # frontend server config
     frontend_ip: str = EnvUtils.get_env("FRONTEND_IP", "127.0.0.1")
-    """server ip address"""
+    """Frontend server ip address"""
     frontend_port: int = EnvUtils.get_env("FRONTEND_PORT", 8848)
-    """server port"""
+    """Frontend server port"""

--- a/utu/env/utils/docker_manager.py
+++ b/utu/env/utils/docker_manager.py
@@ -4,10 +4,11 @@ import time
 from dataclasses import dataclass
 from enum import Enum
 
-import docker
-import docker.errors
 import requests
 from requests.exceptions import RequestException
+
+import docker
+import docker.errors
 
 from .port_manager import PortManager
 

--- a/utu/tools/bash_toolkit.py
+++ b/utu/tools/bash_toolkit.py
@@ -59,10 +59,10 @@ class BashToolkit(AsyncBaseToolkit):
             child.expect(custom_prompt)
         else:
             if sys.platform == "win32":
-                        child = pexpect.spawn("cmd.exe", encoding="utf-8", echo=False, timeout=timeout)
-                        custom_prompt = "PROMPT_>"
-                        child.sendline(f"prompt {custom_prompt}")
-                        child.expect(custom_prompt)
+                child = pexpect.spawn("cmd.exe", encoding="utf-8", echo=False, timeout=timeout)
+                custom_prompt = "PROMPT_>"
+                child.sendline(f"prompt {custom_prompt}")
+                child.expect(custom_prompt)
             else:
                 child = pexpect.spawn("/bin/bash", encoding="utf-8", echo=False, timeout=timeout)
                 # Set a known, unique prompt

--- a/utu/utils/env.py
+++ b/utu/utils/env.py
@@ -8,8 +8,8 @@ load_dotenv(find_dotenv(raise_error_if_not_found=True), verbose=True, override=T
 
 class EnvUtils:
     @staticmethod
-    def get_env(key: str, default: str | None = None, raise_error_if_not_found: bool = True) -> str | None:
-        if raise_error_if_not_found:
+    def get_env(key: str, default: str | None = None) -> str | None:
+        if default is None:
             res = os.getenv(key)
             if not res:
                 raise ValueError(f"Environment variable {key} is not set")

--- a/utu/utils/openai_utils/types.py
+++ b/utu/utils/openai_utils/types.py
@@ -18,6 +18,7 @@ class OpenAICreateBaseParams(TypedDict):
     extra_body: Body | None = None
     timeout: float | httpx.Timeout | None | NotGiven = NOT_GIVEN
 
+
 # CompletionCreateParams | https://platform.openai.com/docs/api-reference/chat/create
 class OpenAIChatCompletionParams(TypedDict, OpenAICreateBaseParams):
     # NOTE: only for typing

--- a/utu/utils/sqlmodel_utils.py
+++ b/utu/utils/sqlmodel_utils.py
@@ -13,7 +13,7 @@ class SQLModelUtils:
     def get_engine(cls):
         if cls._engine is None:
             cls._engine = create_engine(
-                EnvUtils.get_env("DB_URL", raise_error_if_not_found=True),
+                EnvUtils.get_env("DB_URL"),
                 pool_size=300,
                 max_overflow=500,
                 pool_timeout=30,


### PR DESCRIPTION
1. Remove parameter `raise_error_if_not_found` from `get_env` function
2. Fix comments and code formatting issues